### PR TITLE
corrected typos replacing memory allocators with 'device.clone()' 

### DIFF
--- a/src/graphics_pipeline/pipeline_creation.md
+++ b/src/graphics_pipeline/pipeline_creation.md
@@ -117,7 +117,7 @@ To draw the triangle, we need to pass the pipeline, the vertex_buffer and the ac
 
 ```rust
 let mut builder = AutoCommandBufferBuilder::primary(
-    device.clone(),
+    &command_buffer_allocator,
     queue.queue_family_index(),
     CommandBufferUsage::OneTimeSubmit,
 )
@@ -139,7 +139,7 @@ builder
     .draw(
         3, 1, 0, 0, // 3 is the number of vertices, 1 is the number of instances
     )
-    
+
     .unwrap()
     .end_render_pass()
     .unwrap()

--- a/src/graphics_pipeline/render_pass_framebuffer.md
+++ b/src/graphics_pipeline/render_pass_framebuffer.md
@@ -101,7 +101,7 @@ As a demonstration, let's just enter a render pass and leave it immediately afte
 use vulkano::command_buffer::{RenderPassBeginInfo, SubpassContents};
 
 let mut builder = AutoCommandBufferBuilder::primary(
-    device.clone(),
+    &command_buffer_allocator,
     queue.queue_family_index(),
     CommandBufferUsage::OneTimeSubmit,
 )

--- a/src/images/image_clear.md
+++ b/src/images/image_clear.md
@@ -5,6 +5,7 @@ is that you can't modify an image by directly writing to its memory. There is no
 `CpuAccessibleImage`.
 
 <!-- todo: Does vulkano support it now?-->
+
 > **Note**: In reality Vulkan also allows you to create *linear* images, which can be modified but
 > are much slower and are supposed to be used only in some limited situations. Vulkano doesn't
 > support them yet.
@@ -18,7 +19,7 @@ use vulkano::command_buffer::ClearColorImageInfo;
 use vulkano::format::ClearColorValue;
 
 let mut builder = AutoCommandBufferBuilder::primary(
-    device.clone(),
+    &command_buffer_allocator,
     queue.queue_family_index(),
     CommandBufferUsage::OneTimeSubmit,
 )

--- a/src/images/image_creation.md
+++ b/src/images/image_creation.md
@@ -12,6 +12,7 @@ There are various hardcoded formats that the pixels of an image can use.
 
 *Example: the various images used by a Vulkan-using<br />
 application, as seen from a debugger*
+
 </center>
 
 We often use Vulkan images to store *images* in the common sense of the word, in which case each
@@ -66,7 +67,7 @@ use vulkano::image::{ImageDimensions, StorageImage};
 use vulkano::format::Format;
 
 let image = StorageImage::new(
-    device.clone(),
+    &memory_allocator,
     ImageDimensions::Dim2d {
         width: 1024,
         height: 1024,

--- a/src/images/image_export.md
+++ b/src/images/image_export.md
@@ -105,6 +105,7 @@ And that's it! When running your program, a blue image named `image.png` should 
 <img src="guide-image-export-1.png" />
 
 *Here it is.*
+
 </center>
 
 This might look stupid, but think about the fact that it's the GPU that wrote the content of

--- a/src/images/mandelbrot.md
+++ b/src/images/mandelbrot.md
@@ -130,7 +130,7 @@ as seen before:
 
 ```rust
 let image = StorageImage::new(
-    device.clone(),
+    &memory_allocator,
     ImageDimensions::Dim2d {
         width: 1024,
         height: 1024,
@@ -187,7 +187,7 @@ The command buffer contains a dispatch command followed with a copy-image-to-buf
 
 ```rust
 let mut builder = AutoCommandBufferBuilder::primary(
-    device.clone(),
+    &command_buffer_allocator,
     queue.queue_family_index(),
     CommandBufferUsage::OneTimeSubmit,
 )


### PR DESCRIPTION
This fixes the code example errors mentioned in Issue #5, in both the Images and Graphics Pipeline chapters of the book.

"Device.clone()" was written in several places where code expected references to either a standard memory allocator or a command buffer allocator.

I'll note that my editor (MarkText) seems to have added a couple spaces in some spots of the source markdown, but I didn't spot any changes in the formatting when running an instance with mdbook.