### PR TITLE
Fix hidden glsl version being unrendered in Rust string literals

### DIFF
--- a/src/compute_pipeline/compute_pipeline.md
+++ b/src/compute_pipeline/compute_pipeline.md
@@ -127,6 +127,7 @@ To use `vulkano-shaders`, we first have to add a dependency:
 # Notice that it uses the same version as vulkano
 vulkano-shaders = "0.33.0"
 ```
+
 > **Note**: `vulkano-shaders` uses the crate `shaderc-sys` for the actual GLSL compilation step. 
 > When you build your project, an attempt will be made to automatically install shaderc if you 
 > don't already have it. shaderc also comes in [the Vulkan 
@@ -141,7 +142,7 @@ mod cs {
     vulkano_shaders::shader!{
         ty: "compute",
         src: r"
-            #version 460
+            ##version 460
 
             layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 

--- a/src/graphics_pipeline/pipeline_creation.md
+++ b/src/graphics_pipeline/pipeline_creation.md
@@ -139,7 +139,7 @@ builder
     .draw(
         3, 1, 0, 0, // 3 is the number of vertices, 1 is the number of instances
     )
-    
+
     .unwrap()
     .end_render_pass()
     .unwrap()

--- a/src/graphics_pipeline/pipeline_creation.md
+++ b/src/graphics_pipeline/pipeline_creation.md
@@ -27,7 +27,7 @@ mod vs {
     vulkano_shaders::shader!{
         ty: "vertex",
         src: r"
-            #version 460
+            ##version 460
 
             layout(location = 0) in vec2 position;
 
@@ -42,7 +42,7 @@ mod fs {
     vulkano_shaders::shader!{
         ty: "fragment",
         src: "
-            #version 460
+            ##version 460
 
             layout(location = 0) out vec4 f_color;
 

--- a/src/windowing/other_initialization.md
+++ b/src/windowing/other_initialization.md
@@ -84,7 +84,7 @@ mod vs {
     vulkano_shaders::shader! {
         ty: "vertex",
         src: "
-            #version 460
+            ##version 460
 
             layout(location = 0) in vec2 position;
 
@@ -99,7 +99,7 @@ mod fs {
     vulkano_shaders::shader! {
         ty: "fragment",
         src: "
-            #version 460
+            ##version 460
 
             layout(location = 0) out vec4 f_color;
 
@@ -140,7 +140,7 @@ fn main() {
 
     let vs = vs::load(device.clone()).expect("failed to create shader module");
     let fs = fs::load(device.clone()).expect("failed to create shader module");
-    
+
     // crop
 }
 ```

--- a/src/windowing/swapchain_creation.md
+++ b/src/windowing/swapchain_creation.md
@@ -205,7 +205,7 @@ Of all of these properties, we only care about some of them, mainly the dimensio
 transparency (composite alpha), and the format of the images.
 
 ```rust
-let dimensions = surface.window().inner_size();
+let dimensions = window().inner_size();
 let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
 let image_format = Some(
     physical_device
@@ -228,10 +228,7 @@ let (swapchain, images) = Swapchain::new(
         min_image_count: caps.min_image_count + 1, // How many buffers to use in the swapchain
         image_format,
         image_extent: dimensions.into(),
-        image_usage: ImageUsage {
-            color_attachment: true,  // What the images are going to be used for
-            ..Default::default()
-        },
+        image_usage: ImageUsage::COLOR_ATTACHMENT, // What the images are going to be used for
         composite_alpha,
         ..Default::default()
     },


### PR DESCRIPTION
This addresses Issue #8 and escapes the `#` symbol in string literals using `##` so that the glsl version numbers render correctly.