### PR TITLE
Fix: edits typos in book src code to align with tutorial docs' code

### DIFF
--- a/src/07-windowing/03-other-initialization.md
+++ b/src/07-windowing/03-other-initialization.md
@@ -199,7 +199,7 @@ fn main() {
     let mut viewport = Viewport {
         origin: [0.0, 0.0],
         dimensions: window.inner_size().into(),
-        depth_range: 0.0..1.0,
+        depth_range: 0.0..=1.0,
     };
 
     let pipeline = get_pipeline(

--- a/src/07-windowing/04-event-handling.md
+++ b/src/07-windowing/04-event-handling.md
@@ -91,7 +91,7 @@ if window_resized || recreate_swapchain {
     if window_resized {
         window_resized = false;
 
-        viewport.dimensions = new_dimensions.into();
+        viewport.extent = new_dimensions.into();
         let new_pipeline = get_pipeline(
             device.clone(),
             vs.clone(),


### PR DESCRIPTION
Hi, I found some erros in the book for the book that didn't align with the tutorial code on github.
They were in chapter 7.3 and 7.4.
I fixed them to align with the code in github tutorial.