### PR TITLE
Do not needlessly collect iterators

### DIFF
--- a/chapter-code/03-buffer-creation/main.rs
+++ b/chapter-code/03-buffer-creation/main.rs
@@ -57,7 +57,7 @@ fn main() {
     let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     // Example operation
-    let source_content: Vec<i32> = (0..64).collect();
+    let source_content = 0..64;
     let source = Buffer::from_iter(
         memory_allocator.clone(),
         BufferCreateInfo {
@@ -73,7 +73,7 @@ fn main() {
     )
     .expect("failed to create source buffer");
 
-    let destination_content: Vec<i32> = (0..64).map(|_| 0).collect();
+    let destination_content = (0..64).map(|_| 0);
     let destination = Buffer::from_iter(
         memory_allocator.clone(),
         BufferCreateInfo {

--- a/src/03-buffer-creation/02-example-operation.md
+++ b/src/03-buffer-creation/02-example-operation.md
@@ -15,7 +15,7 @@ The first step is to create two CPU-accessible buffers: the source and the desti
 covered in [the previous section](01-buffer-creation.html).
 
 ```rust
-let source_content: Vec<i32> = (0..64).collect();
+let source_content = 0..64;
 let source = Buffer::from_iter(
     memory_allocator.clone(),
     BufferCreateInfo {
@@ -31,7 +31,7 @@ let source = Buffer::from_iter(
 )
 .expect("failed to create source buffer");
 
-let destination_content: Vec<i32> = (0..64).map(|_| 0).collect();
+let destination_content = (0..64).map(|_| 0);
 let destination = Buffer::from_iter(
     memory_allocator.clone(),
     BufferCreateInfo {


### PR DESCRIPTION
Example code aimed at (Rust) learners should avoid such anti-patterns. These variables are never re-used so do not collect it into a vector only to then convert it to an iterator again. It is also more idiomatic to leave out needless type annotations.